### PR TITLE
Add Cloud Pterodactyl wings (CloudLAN Tools) to Gameserver management

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ If you are not sure where to put something, open an issue instead ;)
 - [GameAdminHelper](https://github.com/DavidKMartel/GameAdminHelper) – "Helps manage game servers. Provide a menu for most common game admin tasks. Designed primarily for LAN parties."
 - [LAN game scanner](https://github.com/991jo/lan-game-scanner)
 - [Pterodactyl Panel](https://github.com/pterodactyl/panel) – "Pterodactyl is the open-source game server management panel built with PHP7, Nodejs, and Go. Designed with security in mind, Pterodactyl runs all game servers in isolated Docker containers while exposing a beautiful and intuitive UI to administrators and users."
+- [Cloud Pterodactyl wings (CloudLAN Tools)](https://github.com/cloudlan-tools/cloudlan-tools) - Automatically deploy and manage cloud-based Pterodactyl wings with the use of Terraform or OpenTofu.
 - [gameserver_webinterface](https://github.com/amshove/gameserver_webinterface) – "Webinterface für LAN-Partys zum einfachen Starten/Stoppen/Verwalten von Gameservern."
 - [Wilfred](https://github.com/wilfred-dev/wilfred) – "Wilfred is a command-line interface for running and managing game servers locally. It uses Docker to run game servers in containers, which means they are completely separated. Wilfred can run any game that can run in Docker."
 


### PR DESCRIPTION
Disclaimer: I'm one of the developers behind [CloudLAN Tools](https://github.com/cloudlan-tools). 

We plan to use the added tool, to manage cloud-based Pterodactyl wings, instead of hosting them locally at the event.  
As we are running smaller LAN parties, this tool will allow us to only spend a fraction on servers, in comparison with having local servers.

Using cloud-based game servers always comes with pros and cons.  

The tool can also be used outside LAN parties, but it was specifically designed to handle short-lived Pterodactyl wings.