### PR TITLE
Add Gaming LAN Manager to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ If you are not sure where to put something, open an issue instead ;)
 - [Service Discovery Helper](https://github.com/OpenSourceLAN/service-discovery-helper) – A program that forwards (some) broadcast traffic to other networks.
 - [bcast-bridge](https://git.kopf-tisch.de/razzor/bcast-bridge) – A PHP script that generates iptables rules that forward broadcast traffic to other networks. Used at NorthCon and LANresort.
 - [gamebridge](https://github.com/netwarlan/gamebridge) - Gamebridge allows you to carve up your LAN party network into many VLANs. Usually, this is a no-no for LAN parties due to the broadcasts needed to find local LAN game servers. Gamebridge rebroadcasts those game server finding beacons across many VLANs without passing anything else (ARP, BPDU, other non-game server broadcasts, etc.) using Linux ebtables. Very simple to set up and deploy. Created by [NETWAR](https://www.netwar.org)
-- [Gaming LAN Manager](https://github.com/SovereignBit/GamingLAN) - A secure, split-tunnel WireGuard VPN manager designed specifically for gaming with friends.
+- [Gaming LAN Manager](https://github.com/SovereignBit/GamingLAN) - A specialized WireGuard wrapper to create zero-config Virtual LANs, allowing remote friends to play LAN games over the internet.
 - [QStat](https://github.com/multiplay/qstat) – "A command-line program that displays information about Internet game servers."
 - [GrokStat](https://github.com/vorot93/grokstat) – "Fast game server query tool. Retrieves information about game servers. Inspired by QStat."
 - [Discord Gameserver Notifier](https://github.com/lan-dot-party/Discord-Gameserver-Notifier) - Software so search local network of Gameserver and send Webhook into Discord Channel on new findings

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ If you are not sure where to put something, open an issue instead ;)
 - [Service Discovery Helper](https://github.com/OpenSourceLAN/service-discovery-helper) – A program that forwards (some) broadcast traffic to other networks.
 - [bcast-bridge](https://git.kopf-tisch.de/razzor/bcast-bridge) – A PHP script that generates iptables rules that forward broadcast traffic to other networks. Used at NorthCon and LANresort.
 - [gamebridge](https://github.com/netwarlan/gamebridge) - Gamebridge allows you to carve up your LAN party network into many VLANs. Usually, this is a no-no for LAN parties due to the broadcasts needed to find local LAN game servers. Gamebridge rebroadcasts those game server finding beacons across many VLANs without passing anything else (ARP, BPDU, other non-game server broadcasts, etc.) using Linux ebtables. Very simple to set up and deploy. Created by [NETWAR](https://www.netwar.org)
+- [Gaming LAN Manager](https://github.com/SovereignBit/GamingLAN) - A secure, split-tunnel WireGuard VPN manager designed specifically for gaming with friends.
 - [QStat](https://github.com/multiplay/qstat) – "A command-line program that displays information about Internet game servers."
 - [GrokStat](https://github.com/vorot93/grokstat) – "Fast game server query tool. Retrieves information about game servers. Inspired by QStat."
 - [Discord Gameserver Notifier](https://github.com/lan-dot-party/Discord-Gameserver-Notifier) - Software so search local network of Gameserver and send Webhook into Discord Channel on new findings


### PR DESCRIPTION
Hello! I've added Gaming LAN Manager to the list under the "Network-related software" section.

It is a specialized WireGuard wrapper designed for zero-config LAN gaming over the internet. It automates the setup process by generating the necessary host and friend configuration files for you, removing the need for manual edits.